### PR TITLE
conditional e2e

### DIFF
--- a/common/dp_conf.py
+++ b/common/dp_conf.py
@@ -60,6 +60,9 @@ confs = [
   {'name': 'dp_ui_volume', 'default': -5, 'type': 'Int8', 'min': -5, 'max': 100, 'conf_type': ['param', 'struct']},
   {'name': 'dp_ui_brightness', 'default': 0, 'type': 'UInt8', 'min': 0, 'max': 100, 'conf_type': ['param', 'struct']},
   {'name': 'dp_ui_display_mode', 'default': 0, 'type': 'UInt8', 'min': 0, 'max': 1, 'conf_type': ['param', 'struct']},
+  {'name': 'dp_ui_speed', 'default': True, 'type': 'Bool', 'conf_type': ['param', 'struct']},
+  {'name': 'dp_ui_event', 'default': True, 'type': 'Bool', 'conf_type': ['param', 'struct']},
+  {'name': 'dp_ui_face', 'default': True, 'type': 'Bool', 'conf_type': ['param', 'struct']},
 
   #toyota
   {'name': 'dp_toyota_sng', 'default': False, 'type': 'Bool', 'conf_type': ['param', 'struct']},

--- a/common/dp_conf.py
+++ b/common/dp_conf.py
@@ -126,6 +126,8 @@ confs = [
   # # toyota
   {'name': 'dp_toyota_rav4_tss2_tune', 'default': False, 'type': 'Bool', 'conf_type': ['param']},
   {'name': 'dp_toyota_prius_bad_angle_tune', 'default': False, 'type': 'Bool', 'conf_type': ['param']},
+  {'name': 'dp_e2e_conditional', 'default': False, 'type': 'Bool', 'conf_type': ['param', 'struct']},
+  {'name': 'dp_e2e_conditional_at_speed', 'default': 60, 'type': 'UInt8', 'min': 0, 'max': 100, 'depends': [{'name': 'dp_e2e_conditional', 'vals': [True]}], 'conf_type': ['param', 'struct']},
   # {'name': 'dp_toyota_no_min_acc_limit', 'default': False, 'type': 'Bool', 'conf_type': ['param']},
   # {'name': 'dp_toyota_ldw', 'default': True, 'type': 'Bool', 'conf_type': ['param', 'struct']},
   # {'name': 'dp_toyota_zss', 'default': False, 'type': 'Bool', 'conf_type': ['param']},

--- a/common/params.cc
+++ b/common/params.cc
@@ -261,6 +261,8 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"dp_lateral_torque_live_tune", PERSISTENT},
     {"dp_toyota_rav4_tss2_tune", PERSISTENT},
     {"dp_toyota_prius_bad_angle_tune", PERSISTENT},
+    {"dp_e2e_conditional", PERSISTENT},
+    {"dp_e2e_conditional_at_speed", PERSISTENT},
 };
 
 } // namespace

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -84,6 +84,12 @@ def limit_accel_in_turns(v_ego, angle_steers, a_target, CP):
 
 class LongitudinalPlanner:
   def __init__(self, CP, init_v=0.0, init_a=0.0):
+    # dp - conditional e2e
+    self.dp_e2e_conditional = False
+    self.dp_e2e_conditional_at_speed = 0
+    self.dp_e2e_v_cruise_kph = 0
+    self.dp_e2e_has_lead = False
+
     self.CP = CP
     self.params = Params()
     self.param_read_counter = 0
@@ -110,12 +116,6 @@ class LongitudinalPlanner:
     self.speed_limit_controller = SpeedLimitController()
     self.events = Events()
     self.turn_speed_controller = TurnSpeedController()
-
-    # dp - conditional e2e
-    self.dp_e2e_conditional = False
-    self.dp_e2e_conditional_at_speed = 0
-    self.dp_e2e_v_cruise_kph = 0
-    self.dp_e2e_has_lead = False
 
   def read_param(self):
     e2e = self.params.get_bool('EndToEndLong') and self.CP.openpilotLongitudinalControl

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -125,13 +125,14 @@ class LongitudinalPlanner:
     # 2. acc set speed is below dp_e2e_conditional_at_speed.
     # notes. when dp_e2e_conditional_at_speed is 0, we don't use speed condition.
     # example:
-    # * when speed condition is 60 and I set acc to 50 and there is no lead car, I would like to use e2e (e.g. traffic light)
-    # * when speed condition is 60 and I set acc to 80 and there is no lead car, I would like to use acc.
-    # * when speed condition is 60 I set acc to 50 and there is a lead car, I would like to use acc.
-    # * when speed condition is 0 and I set acc to 60 and there is a lead car, I would like to use acc.
-    # * when speed condition is 0 and I set acc to 60 and there is no lead car, I would like to use e2e.
+    # * when speed condition is 60 and I set acc to 50 and - lead, use e2e (e.g. traffic light)
+    # * when speed condition is 60 and I set acc to 80 and - lead, use acc.
+    # * when speed condition is 60 I set acc to 50 and  + lead, use acc.
+    # * when speed condition is 60 I set acc to 80 and + lead, use acc.
+    # * when speed condition is 0 and I set acc to 60 and + lead, use acc.
+    # * when speed condition is 0 and I set acc to 60 and - lead, use e2e.
     if e2e and self.dp_e2e_conditional:
-      if self.dp_e2e_has_lead or (self.dp_e2e_conditional_at_speed > 0 and self.dp_e2e_v_cruise_kph <= self.dp_e2e_conditional_at_speed):
+      if self.dp_e2e_has_lead or (0 < self.dp_e2e_conditional_at_speed <= self.dp_e2e_v_cruise_kph):
         e2e = False
     self.mpc.mode = 'blended' if e2e else 'acc'
 

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -161,6 +161,7 @@ class LongitudinalPlanner:
       if self.dp_e2e_mode != self.dp_e2e_mode_last:
         put_bool_nonblocking('EndToEndLong', True if self.dp_e2e_mode == 'blended' else False)
         self.mpc.mode = self.dp_e2e_mode
+      self.dp_e2e_mode = self.dp_e2e_mode_last
 
   def parse_model(self, model_msg):
     if (len(model_msg.position.x) == 33 and

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -6,7 +6,7 @@ from common.numpy_fast import interp
 import cereal.messaging as messaging
 from common.conversions import Conversions as CV
 from common.filter_simple import FirstOrderFilter
-from common.params import Params
+from common.params import Params, put_bool_nonblocking
 from common.realtime import DT_MDL
 from selfdrive.modeld.constants import T_IDXS
 from selfdrive.controls.lib.longcontrol import LongCtrlState
@@ -51,6 +51,9 @@ _DP_CRUISE_MAX_V_ECO = [2.7, 1.4, 1.2, 0.7, 0.48, 0.35, 0.25, 0.15, 0.12, 0.06]
 _DP_CRUISE_MAX_V_SPORT = [3.5, 3.5, 2.5, 1.5, 2.0, 2.0, 2.0, 1.5, 1.0, 0.5]
 _DP_CRUISE_MAX_BP = [0., 3, 6., 8., 11., 15., 20., 25., 30., 55.]
 
+# count n times before we decide a lead is there or not
+_DP_E2E_LEAD_COUNT = 100
+
 def dp_calc_cruise_accel_limits(v_ego, dp_profile):
   if dp_profile == DP_ACCEL_ECO:
     a_cruise_min = interp(v_ego, _DP_CRUISE_MIN_BP, _DP_CRUISE_MIN_V_ECO)
@@ -89,6 +92,11 @@ class LongitudinalPlanner:
     self.dp_e2e_conditional_at_speed = 0
     self.dp_e2e_v_cruise_kph = 0
     self.dp_e2e_has_lead = False
+    self.dp_e2e_lead = False
+    self.dp_e2e_lead_last = False
+    self.dp_e2e_lead_count = 0
+    self.dp_e2e_mode = 'acc'
+    self.dp_e2e_mode_last = 'acc'
 
     self.CP = CP
     self.params = Params()
@@ -119,6 +127,9 @@ class LongitudinalPlanner:
 
   def read_param(self):
     e2e = self.params.get_bool('EndToEndLong') and self.CP.openpilotLongitudinalControl
+    self.mpc.mode = 'blended' if e2e else 'acc'
+
+  def conditional_e2e(self):
     # dp - conditional e2e
     # we fall back to normal mode when:
     # 1. there is a lead car ahead or
@@ -131,10 +142,25 @@ class LongitudinalPlanner:
     # * when speed condition is 60 kph and I set acc to 80 kph and + lead, use acc.
     # * when speed condition is 0 kph and I set acc to 60 kph and + lead, use acc.
     # * when speed condition is 0 kph and I set acc to 60 kph and - lead, use e2e.
-    if e2e and self.dp_e2e_conditional:
+    if self.CP.openpilotLongitudinalControl:
+      # we don't want to switch mode too frequently due to lead comes and goes
+      # so count the lead continuously of _DP_E2E_LEAD_COUNT times then update lead status
+      if self.dp_e2e_lead != self.dp_e2e_lead_last:
+        self.dp_e2e_lead_count = 0
+      else:
+        self.dp_e2e_lead_count += 1
+      self.dp_e2e_lead = self.dp_e2e_lead_last
+
+      if self.dp_e2e_lead_count >= _DP_E2E_LEAD_COUNT:
+        self.dp_e2e_has_lead = self.dp_e2e_lead
+
       if self.dp_e2e_has_lead or (0 < self.dp_e2e_conditional_at_speed <= self.dp_e2e_v_cruise_kph):
-        e2e = False
-    self.mpc.mode = 'blended' if e2e else 'acc'
+        self.dp_e2e_mode = 'acc'
+      else:
+        self.dp_e2e_mode = 'blended'
+      if self.dp_e2e_mode != self.dp_e2e_mode_last:
+        put_bool_nonblocking('EndToEndLong', True if self.dp_e2e_mode == 'blended' else False)
+        self.mpc.mode = self.dp_e2e_mode
 
   def parse_model(self, model_msg):
     if (len(model_msg.position.x) == 33 and
@@ -155,17 +181,19 @@ class LongitudinalPlanner:
     return x, v, a, j
 
   def update(self, sm):
-    if self.param_read_counter % 50 == 0:
-      self.read_param()
-    self.param_read_counter += 1
-
     # dp
     self.dp_accel_profile_ctrl = sm['dragonConf'].dpAccelProfileCtrl
     self.dp_accel_profile = sm['dragonConf'].dpAccelProfile
-    self.dp_e2e_conditional = sm['dragonConf'].dpE2EConditional
     self.dp_e2e_conditional_at_speed = sm['dragonConf'].dpE2EConditionalAtSpeed
     self.dp_e2e_v_cruise_kph = sm['controlsState'].vCruise
-    self.dp_e2e_has_lead = sm['radarState'].leadOne.status
+    self.dp_e2e_lead = sm['radarState'].leadOne.status
+
+    if sm['dragonConf'].dpE2EConditional:
+      self.conditional_e2e()
+    else:
+      if self.param_read_counter % 50 == 0:
+        self.read_param()
+      self.param_read_counter += 1
 
     v_ego = sm['carState'].vEgo
     v_cruise_kph = sm['controlsState'].vCruise

--- a/selfdrive/sentry.py
+++ b/selfdrive/sentry.py
@@ -22,7 +22,7 @@ class SentryProject(Enum):
   # native project
   SELFDRIVE_NATIVE = "https://980a0cba712a4c3593c33c78a12446e1@o273754.ingest.sentry.io/1488600"
 
-CRASHES_DIR = '/data/community/crashes'
+CRASHES_DIR = '/data/media/0/crash_logs'
 
 ret = car.CarParams.new_message()
 candidate = ret.carFingerprint
@@ -68,7 +68,7 @@ def save_exception(exc_text):
   if not os.path.exists(CRASHES_DIR):
     os.makedirs(CRASHES_DIR)
 
-  log_file = '{}/{}'.format(CRASHES_DIR, datetime.now().strftime('%m-%d-%Y--%I:%M.%S-%p.log'))
+  log_file = '{}/{}'.format(CRASHES_DIR, datetime.now().strftime('%Y-%m-%d-%H-%M-%S.log'))
   with open(log_file, 'w') as f:
     f.write(exc_text)
   print('Logged current crash to {}'.format(log_file))

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -200,9 +200,9 @@ static void update_state(UIState *s) {
     scene.dpAccelProfile = dragonConf.getDpAccelProfile();
     scene.dpUiBrightness = dragonConf.getDpUiBrightness();
     scene.dpE2EConditional = dragonConf.getDpE2EConditional();
-    if (scene.dpE2EConditional) {
-      s->scene.end_to_end_long = sm["longitudinalPlan"].getLongitudinalPlan().getDpE2EIsBlended();
-    }
+  }
+  if (scene.dpE2EConditional) {
+    s->scene.end_to_end_long = sm["longitudinalPlan"].getLongitudinalPlan().getDpE2EIsBlended();
   }
 }
 

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -189,13 +189,30 @@ static void update_state(UIState *s) {
     scene.light_sensor = std::clamp<float>(1.0 - (ev / max_ev), 0.0, 1.0);
   }
   scene.started = sm["deviceState"].getDeviceState().getStarted() && scene.ignition;
+  if (sm.updated("dragonConf")) {
+    auto dragonConf = sm["dragonConf"].getDragonConf();
+    scene.dpUiDisplayMode = dragonConf.getDpUiDisplayMode();
+    scene.dpIpAddr = dragonConf.getDpIpAddr();
+    scene.dpLocale = dragonConf.getDpLocale();
+    scene.dpFollowingProfileCtrl = dragonConf.getDpFollowingProfileCtrl();
+    scene.dpFollowingProfile = dragonConf.getDpFollowingProfile();
+    scene.dpAccelProfileCtrl = dragonConf.getDpAccelProfileCtrl();
+    scene.dpAccelProfile = dragonConf.getDpAccelProfile();
+    scene.dpUiBrightness = dragonConf.getDpUiBrightness();
+    scene.dpE2EConditional = dragonConf.getDpE2EConditional();
+    if (scene.dpE2EConditional) {
+      s->scene.end_to_end_long = sm["longitudinalPlan"].getLongitudinalPlan().getDpE2EIsBlended();
+    }
+  }
 }
 
 void ui_update_params(UIState *s) {
   auto params = Params();
   s->scene.is_metric = params.getBool("IsMetric");
   s->scene.map_on_left = params.getBool("NavSettingLeftSide");
-  s->scene.end_to_end_long = params.getBool("EndToEndLong");
+  if (!s->scene.dpE2EConditional) {
+    s->scene.end_to_end_long = params.getBool("EndToEndLong");
+  }
 }
 
 void UIState::updateStatus() {
@@ -233,7 +250,7 @@ UIState::UIState(QObject *parent) : QObject(parent) {
   sm = std::make_unique<SubMaster, const std::initializer_list<const char *>>({
     "modelV2", "controlsState", "liveCalibration", "radarState", "deviceState", "roadCameraState",
     "pandaStates", "carParams", "driverMonitoringState", "sensorEvents", "carState", "liveLocationKalman",
-    "wideRoadCameraState", "managerState", "navInstruction", "navRoute", "gnssMeasurements",
+    "wideRoadCameraState", "managerState", "navInstruction", "navRoute", "gnssMeasurements", "dragonConf",
     "longitudinalPlan", "liveMapData",
   });
 

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -121,6 +121,18 @@ typedef struct UIScene {
   float light_sensor, accel_sensor, gyro_sensor;
   bool started, ignition, is_metric, map_on_left, longitudinal_control, end_to_end_long;
   uint64_t started_frame;
+
+  //dp
+  std::string dpIpAddr;
+  std::string dpLocale;
+  bool dpFollowingProfileCtrl;
+  int dpFollowingProfile;
+  bool dpAccelProfileCtrl;
+  int dpAccelProfile;
+  int dpUiBrightness;
+  int dpUiDisplayMode;
+  int brightness;
+  bool dpE2EConditional;
 } UIScene;
 
 class UIState : public QObject {


### PR DESCRIPTION
    # dp - conditional e2e
    # we fall back to normal mode when:
    # 1. there is a lead car ahead or
    # 2. acc set speed is below dp_e2e_conditional_at_speed.
    # notes. when dp_e2e_conditional_at_speed is 0, we don't use speed condition.
    # example:
    # * when speed condition is 60 and I set acc to 50 and there is no lead car, I would like to use e2e (e.g. traffic light)
    # * when speed condition is 60 and I set acc to 80 and there is no lead car, I would like to use acc.
    # * when speed condition is 60 I set acc to 50 and there is a lead car, I would like to use acc.
    # * when speed condition is 0 and I set acc to 60 and there is a lead car, I would like to use acc.
    # * when speed condition is 0 and I set acc to 60 and there is no lead car, I would like to use e2e.
@rav4kumar what do you think?